### PR TITLE
fix bug of srf_diag when use urban model and aggregation_urban & add lc_year in mksrfdata

### DIFF
--- a/main/CLM.F90
+++ b/main/CLM.F90
@@ -392,6 +392,8 @@ PROGRAM CLM
 
          CALL allocate_1D_Forcing
          CALL allocate_1D_Fluxes
+
+         CALL forcing_init (dir_forcing, deltim, sdate)
       ENDIF
 #endif
 

--- a/main/LEAF_temperature.F90
+++ b/main/LEAF_temperature.F90
@@ -387,11 +387,11 @@ USE PhysicalConstants, only: tfrz
    REAL(r8) :: utop, ueff, ktop
    REAL(r8) :: phih, z0qg, z0hg
    REAL(r8) :: hsink, displasink
-#ifdef PLANT_HYDRAULIC_STRESS
-   real(r8) gb_mol_sun,gb_mol_sha
 #ifndef WUEdiag
    real(r8) etrsun,etrsha
 #endif
+#ifdef PLANT_HYDRAULIC_STRESS
+   real(r8) gb_mol_sun,gb_mol_sha
    real(r8),dimension(nl_soil) :: k_soil_root    ! radial root and soil conductance
    real(r8),dimension(nl_soil) :: k_ax_root      ! axial root conductance
 #endif

--- a/main/lulcc/LuLccInitialize.F90
+++ b/main/lulcc/LuLccInitialize.F90
@@ -75,7 +75,7 @@ SUBROUTINE LuLccInitialize (casename,dir_landdata,dir_restart,&
 
    REAL(r8) rlat          !latitude in radians
    REAL(r8) rlon          !longitude in radians
-  
+
    LOGICAL  :: use_wtd
 
    CHARACTER(len=256) :: fwtd
@@ -167,9 +167,11 @@ SUBROUTINE LuLccInitialize (casename,dir_landdata,dir_restart,&
 #ifdef PC_CLASSIFICATION
       CALL landpc%forc_free_mem
 #endif
+#ifdef URBAN_MODEL
       CALL landurban%forc_free_mem
+#endif
    ! ENDIF
-   
+
    ! load pixelset and mesh data of next year
    !call pixel%load_from_file  (dir_landdata)
    !call gblock%load_from_file (dir_landdata)
@@ -180,7 +182,7 @@ SUBROUTINE LuLccInitialize (casename,dir_landdata,dir_restart,&
    !TODO: LC_YEAR or simulation year?
    CALL pixelset_load_from_file (year, dir_landdata, 'landhru', landhru, numhru)
 #endif
-  
+
    call pixelset_load_from_file (year, dir_landdata, 'landpatch', landpatch, numpatch)
 
 #ifdef PFT_CLASSIFICATION
@@ -197,7 +199,7 @@ SUBROUTINE LuLccInitialize (casename,dir_landdata,dir_restart,&
    CALL map_patch_to_urban
 #endif
 
-#if (defined UNSTRUCTURED || defined CATCHMENT) 
+#if (defined UNSTRUCTURED || defined CATCHMENT)
    CALL elm_vector_init ()
 #ifdef CATCHMENT
    CALL hru_vector_init ()

--- a/main/mod_forcing.F90
+++ b/main/mod_forcing.F90
@@ -101,6 +101,8 @@ contains
       deltim_real = deltatime
 
       ! set initial values
+      IF (allocated(tstamp_LB)) deallocate(tstamp_LB)
+      IF (allocated(tstamp_UB)) deallocate(tstamp_UB)
       allocate (tstamp_LB(NVAR))
       allocate (tstamp_UB(NVAR))
       tstamp_LB(:) = timestamp(-1, -1, -1)
@@ -110,6 +112,9 @@ contains
 
       if (p_is_io) then
 
+         IF (allocated(forcn   )) deallocate(forcn   )
+         IF (allocated(forcn_LB)) deallocate(forcn_LB)
+         IF (allocated(forcn_UB)) deallocate(forcn_UB)
          allocate (forcn    (NVAR))
          allocate (forcn_LB (NVAR))
          allocate (forcn_UB (NVAR))

--- a/main/user_specified_forcing.F90
+++ b/main/user_specified_forcing.F90
@@ -91,9 +91,14 @@ CONTAINS
 
       NVAR = DEF_forcing%NVAR
 
+      IF (allocated(dtime )) deallocate(dtime)
+      IF (allocated(offset)) deallocate(offset)
       allocate (dtime  (NVAR))
       allocate (offset (NVAR))
 
+      IF (allocated(fprefix )) deallocate(fprefix )
+      IF (allocated(vname   )) deallocate(vname   )
+      IF (allocated(tintalgo)) deallocate(tintalgo)
       allocate (fprefix  (NVAR))
       allocate (vname    (NVAR))
       allocate (tintalgo (NVAR))
@@ -150,17 +155,17 @@ CONTAINS
       !DESCRIPTION
       !===========
          !---Princeton Global Meteorological Forcing Dataset for Land Surface Modeling
-   
+
       !data source:
       !-------------------
          !---https://rda.ucar.edu/datasets/ds314.0/
 
       !References:
       !-------------------
-         !---Sheffield, J., G. Goteti, and E. F. Wood, 2006: Development of a 50-year high-resolution 
-         !   global dataset of meteorological forcings for land surface modeling J. Climate, 19(13), 
+         !---Sheffield, J., G. Goteti, and E. F. Wood, 2006: Development of a 50-year high-resolution
+         !   global dataset of meteorological forcings for land surface modeling J. Climate, 19(13),
          !   3088-3111.
-         
+
       !REVISION HISTORY
       !----------------
          !---2022.05.01   Zhongwang Wei @ SYSU: remove the "z" dimension
@@ -170,7 +175,7 @@ CONTAINS
       !DESCRIPTION
       !===========
          !---Global Meteorological Forcing Dataset for Global Soil Wetness Project Phase 3
-   
+
       !data source:
       !-------------------
          !---http://hydro.iis.u-tokyo.ac.jp/GSWP3/
@@ -181,7 +186,7 @@ CONTAINS
          !---Dirmeyer, P. A., Gao, X., Zhao, M., Guo, Z., Oki, T. and Hanasaki, N. (2006) GSWP-2:
          !   Multimodel Analysis and Implications for Our Perception of the Land Surface. Bulletin
          !   of the American Meteorological Society, 87(10), 1381–98.
-         
+
       !REVISION HISTORY
       !----------------
          !---
@@ -190,7 +195,7 @@ CONTAINS
       !DESCRIPTION
       !===========
          !---Qian Global Meteorological Forcing Dataset from 1948 to 2004
-   
+
       !data source:
       !-------------------
          !---Not available now!
@@ -199,10 +204,10 @@ CONTAINS
       !-------------------
          !---Qian T., and co-authors, 2006: Simulation of Global Land Surface Conditions from 1948 to 2004.
          !   Part I: Forcing Data and Evaluations. J. Hydrometeorol., 7, 953-975.
-         
+
       !REVISION HISTORY
       !----------------
-         !---   
+         !---
 
          metfilename = '/'//trim(fprefix(var_i))//trim(yearstr)//'-'//trim(monthstr)//'.nc'
       case ('CRUNCEPV4') ! CRUNCEP V4 forcing data
@@ -216,19 +221,19 @@ CONTAINS
 
       !References:
       !-------------------
-         !---Viovy, N. (2010), CRU‐NCEP dataset. 
+         !---Viovy, N. (2010), CRU‐NCEP dataset.
          !   [Available at: http://dods.extra.cea.fr/data/p529viov/cruncep/readme.htm.]
 
       !REVISION HISTORY
       !----------------
-         !---      
+         !---
 
          metfilename = '/'//trim(fprefix(var_i))//trim(yearstr)//'-'//trim(monthstr)//'.nc'
       case ('CRUNCEPV7') ! CRUNCEP V7 forcing data
       !DESCRIPTION
       !===========
          !---CRUNCEP Version 7 - Atmospheric Forcing Data for the Community Land Model
-   
+
       !data source:
       !-------------------
          !---https://rda.ucar.edu/datasets/ds314.3/
@@ -236,22 +241,22 @@ CONTAINS
       !References:
       !-------------------
          !---Viovy, Nicolas. (2018). CRUNCEP Version 7 -
-         !   Atmospheric Forcing Data for the Community Land Model. 
-         !   Research Data Archive at the National Center for Atmospheric Research, 
-         !   Computational and Information Systems Laboratory. 
+         !   Atmospheric Forcing Data for the Community Land Model.
+         !   Research Data Archive at the National Center for Atmospheric Research,
+         !   Computational and Information Systems Laboratory.
          !   https://doi.org/10.5065/PZ8F-F017. Accessed 05 May 2023.
 
       !REVISION HISTORY
       !----------------
-         !--- 
+         !---
 
          metfilename = '/'//trim(fprefix(var_i))//trim(yearstr)//'-'//trim(monthstr)//'.nc'
       case ('ERA5LAND') ! ERA5-Land forcing data
       !DESCRIPTION
       !===========
-         !---enhanced global dataset for the land component of the fifth 
+         !---enhanced global dataset for the land component of the fifth
          !   generation of European ReAnalysis (ERA5)
-   
+
       !data source:
       !-------------------
          !---https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land?tab=form
@@ -260,7 +265,7 @@ CONTAINS
       !-------------------
          !---Muñoz-Sabater, J., Dutra, E., Agustí-Panareda, A., Albergel, C., Arduini, G., Balsamo, G., Boussetta, S.,
          !   Choulga, M., Harrigan, S., Hersbach, H. and Martens, B., 2021. ERA5-Land:
-         !   A state-of-the-art global reanalysis dataset for land applications. Earth System 
+         !   A state-of-the-art global reanalysis dataset for land applications. Earth System
          !   Science Data, 13(9), pp.4349-4383.
 
       !REVISION HISTORY
@@ -290,7 +295,7 @@ CONTAINS
       !DESCRIPTION
       !===========
          !---The fifth generation of European ReAnalysis (ERA5)
-   
+
       !data source:
       !-------------------
          !---https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels?tab=overview
@@ -298,9 +303,9 @@ CONTAINS
       !References:
       !-------------------
          !---Hersbach, H., Bell, B., Berrisford, P., Hirahara, S., Horányi, A., Muñoz‐Sabater, J.,
-         !   Nicolas, J., Peubey, C., Radu, R., Schepers, D. and Simmons, A., 2020. 
+         !   Nicolas, J., Peubey, C., Radu, R., Schepers, D. and Simmons, A., 2020.
          !   The ERA5 global reanalysis. Quarterly Journal of the Royal Meteorological Society, 146(730), pp.1999-2049.
-   
+
       !REVISION HISTORY
       !----------------
          !---2021.11.01   Zhongwang Wei @ SYSU: zip file to reduce the size of the data; remove offset and scale_factor
@@ -328,7 +333,7 @@ CONTAINS
       !DESCRIPTION
       !===========
          !---Multi-Source Weather forcing data
-   
+
       !data source:
       !-------------------
          !---https://www.gloh2o.org/mswx/
@@ -341,14 +346,14 @@ CONTAINS
 
       !REVISION HISTORY
       !----------------
-         !---2021.11.01   Zhongwang Wei @ SYSU: Regroup data into monthly 
+         !---2021.11.01   Zhongwang Wei @ SYSU: Regroup data into monthly
 
          metfilename = '/'//trim(fprefix(var_i))//'_'//trim(yearstr)//'_'//trim(monthstr)//'.nc'
       case ('WFDE5')
       !DESCRIPTION
       !===========
          !---WATCH Forcing Data methodology applied to ERA5 reanalysis data
-   
+
       !data source:
       !-------------------
          !---https://doi.org/10.24381/cds.20d54e34
@@ -367,19 +372,19 @@ CONTAINS
       case ('CRUJRA')
       !DESCRIPTION
       !===========
-         !---Collection of CRU JRA forcing datasets of gridded land surface blend 
+         !---Collection of CRU JRA forcing datasets of gridded land surface blend
          !   of Climatic Research Unit (CRU) and Japanese reanalysis (JRA) data
-   
+
       !data source:
       !-------------------
          !---https://catalogue.ceda.ac.uk/uuid/863a47a6d8414b6982e1396c69a9efe8
 
       !References:
       !-------------------
-         !---University of East Anglia Climatic Research Unit; Harris, I.C. (2019): 
+         !---University of East Anglia Climatic Research Unit; Harris, I.C. (2019):
          !   CRU JRA: Collection of CRU JRA forcing datasets of gridded land surface blend
          !   of Climatic Research Unit (CRU) and Japanese reanalysis (JRA) data..
-         ! Centre for Environmental Data Analysis, date of citation. 
+         ! Centre for Environmental Data Analysis, date of citation.
          !http://catalogue.ceda.ac.uk/uuid/863a47a6d8414b6982e1396c69a9efe8
 
       !REVISION HISTORY
@@ -393,7 +398,7 @@ CONTAINS
       !DESCRIPTION
       !===========
          !---WATCH Forcing Data methodology applied to ERA-Interim reanalysis data
-   
+
       !data source:
       !-------------------
          !---https://doi.org/10.24381/cds.20d54e34
@@ -413,7 +418,7 @@ CONTAINS
       !DESCRIPTION
       !===========
          !---the Japanese 55-year Reanalysis
-   
+
       !data source:
       !-------------------
          !---https://jra.kishou.go.jp/JRA-55/index_en.html
@@ -425,21 +430,21 @@ CONTAINS
          !   The JRA-55 Reanalysis: General specifications and basic characteristics.
          !   J. Meteor. Soc. Japan, 93, 5-48, doi:10.2151/jmsj.2015-001.
          !---Harada, Y., H. Kamahori, C. Kobayashi, H. Endo, S. Kobayashi, Y. Ota, H. Onoda,
-         !   K. Onogi, K. Miyaoka, and K. Takahashi, 2016: The JRA-55 Reanalysis: 
-         !   Representation of atmospheric circulation and climate variability, J. Meteor. Soc. Japan, 
+         !   K. Onogi, K. Miyaoka, and K. Takahashi, 2016: The JRA-55 Reanalysis:
+         !   Representation of atmospheric circulation and climate variability, J. Meteor. Soc. Japan,
          !   94, 269-302, doi:10.2151/jmsj.2016-015.
 
       !REVISION HISTORY
       !----------------
          !---2021.11.01   Zhongwang Wei @ SYSU: zip file to reduce the size of the data; remove offset and scale_factor
-      
+
 
          metfilename = '/'//trim(fprefix(var_i))//'_'//trim(yearstr)//'.nc'
       case ('GDAS')
       !DESCRIPTION
       !===========
          !--- Forcing Data From Global Data Assimilation System
-   
+
       !data source:
       !-------------------
          !--https://disc.sci.gsfc.nasa.gov/datasets/GLDAS_NOAH025_3H_V2.1/summary
@@ -447,11 +452,11 @@ CONTAINS
       !References:
       !-------------------
          !---Beaudoing, H. and M. Rodell, NASA/GSFC/HSL (2020), GLDAS Noah Land Surface Model L4 3 hourly 0.25 x 0.25
-         !   degree V2.1, Greenbelt, Maryland, USA, Goddard Earth Sciences Data and Information Services 
+         !   degree V2.1, Greenbelt, Maryland, USA, Goddard Earth Sciences Data and Information Services
          !   Center (GES DISC), Accessed: [Data Access Date], 10.5067/E7TYRXPJKWOQ
-         !---Rodell, M., P.R. Houser, U. Jambor, J. Gottschalck, K. Mitchell, C. Meng, K. Arsenault, B. Cosgrove, 
+         !---Rodell, M., P.R. Houser, U. Jambor, J. Gottschalck, K. Mitchell, C. Meng, K. Arsenault, B. Cosgrove,
          !   J. Radakovich, M. Bosilovich, J.K. Entin, J.P. Walker, D. Lohmann, and D. Toll, 2004:
-         !   The Global Land Data Assimilation System, Bull. Amer. Meteor. Soc., 85, 381-394, 
+         !   The Global Land Data Assimilation System, Bull. Amer. Meteor. Soc., 85, 381-394,
          !   doi:10.1175/BAMS-85-3-381
 
       !REVISION HISTORY
@@ -460,20 +465,20 @@ CONTAINS
 
          metfilename = '/'//trim(fprefix(var_i))//trim(yearstr)//trim(monthstr)//'.nc4'
       case ('CLDAS')
-      
+
       !DESCRIPTION
       !===========
-         !---The Real-Time Product Dataset Of The China Meteorological Administration 
+         !---The Real-Time Product Dataset Of The China Meteorological Administration
          !   Land Data Assimilation System
-   
+
       !data source:
       !-------------------
          !--CMA, not pulicly available
 
       !References:
       !-------------------
-         !---Xia, Y.L.; Hao, Z.C.; Shi, C.X.; Li, Y.H.; Meng, J.; Xu, T.R.; Wu, X.Y.; Zhang, B.Q. 
-         !    Regional and global land data assimilation systems: Innovations, challenges, and 
+         !---Xia, Y.L.; Hao, Z.C.; Shi, C.X.; Li, Y.H.; Meng, J.; Xu, T.R.; Wu, X.Y.; Zhang, B.Q.
+         !    Regional and global land data assimilation systems: Innovations, challenges, and
          !    prospects. J. Meteorol. Res. 2019, 33, 159–189.
 
       !REVISION HISTORY
@@ -485,17 +490,17 @@ CONTAINS
       !DESCRIPTION
       !===========
          !--- The China Meteorological Forcing Dataset
-   
+
       !data source:
       !-------------------
          !--https://data.tpdc.ac.cn/en/data/8028b944-daaa-4511-8769-965612652c49/
 
       !References:
       !-------------------
-         !---He, J., Yang, K., Tang, W., Lu, H., Qin, J., Chen, Y. and Li, X., 2020. 
-         !   The first high-resolution meteorological forcing dataset for land process 
+         !---He, J., Yang, K., Tang, W., Lu, H., Qin, J., Chen, Y. and Li, X., 2020.
+         !   The first high-resolution meteorological forcing dataset for land process
          !   studies over China. Scientific data, 7(1), p.25.
-      
+
          !REVISION HISTORY
       !----------------
          !---
@@ -505,7 +510,7 @@ CONTAINS
       !DESCRIPTION
       !===========
          !---the Climate Model Intercomparison Project Phase 6 (CMIP6) forcing data sets
-   
+
       !data source:
       !-------------------
          !---https://esgf-node.llnl.gov/projects/cmip6/
@@ -513,10 +518,10 @@ CONTAINS
       !References:
       !-------------------
          !---
-      
+
          !REVISION HISTORY
       !----------------
-         !---2021.11.01   Zhongwang Wei @ SYSU: regroup the data into monthly file; 
+         !---2021.11.01   Zhongwang Wei @ SYSU: regroup the data into monthly file;
          !   zip file to reduce the size of the data; remove offset and scale_factor
 
 
@@ -524,8 +529,8 @@ CONTAINS
       case ('TPMFD')
       !DESCRIPTION
       !===========
-         !---A high-resolution near-surface meteorological forcing dataset for the Third Pole region 
-   
+         !---A high-resolution near-surface meteorological forcing dataset for the Third Pole region
+
       !data source:
       !-------------------
          !---https://data.tpdc.ac.cn/zh-hans/data/44a449ce-e660-44c3-bbf2-31ef7d716ec7
@@ -533,14 +538,14 @@ CONTAINS
       !References:
       !-------------------
          !---Yang, K., Jiang, Y., Tang, W., He, J., Shao, C., Zhou, X., Lu, H.,
-         !   Chen, Y., Li, X., Shi, J. (2023). A high-resolution near-surface 
+         !   Chen, Y., Li, X., Shi, J. (2023). A high-resolution near-surface
          !   meteorological forcing dataset for the Third Pole region （TPMFD, 1979-2020）.
-         !   National Tibetan Plateau/Third Pole Environment Data Center, 
+         !   National Tibetan Plateau/Third Pole Environment Data Center,
          !   https://doi.org/10.11888/Atmos.tpdc.300398. https://cstr.cn/18406.11.Atmos.tpdc.300398.
-      
+
       !REVISION HISTORY
       !----------------
-         !---2021.11.01   Zhongwang Wei @ SYSU: regroup the data into monthly file; 
+         !---2021.11.01   Zhongwang Wei @ SYSU: regroup the data into monthly file;
          !   zip file to reduce the size of the data; remove offset and scale_factor
 
          metfilename = '/'//trim(fprefix(var_i))//trim(yearstr)//trim(monthstr)//'.nc'

--- a/mkinidata/Urban_readin.F90
+++ b/mkinidata/Urban_readin.F90
@@ -71,7 +71,7 @@ SUBROUTINE Urban_readin (year, dir_landdata)!(dir_srfdata,dir_atmdata,nam_urbdat
       CALL ncio_read_vector (lndname, 'EM_WALL'       , landurban, em_wall) ! emissivity of wall
       CALL ncio_read_vector (lndname, 'EM_IMPROAD'    , landurban, em_gimp) ! emissivity of impervious road
       CALL ncio_read_vector (lndname, 'EM_PERROAD'    , landurban, em_gper) ! emissivity of pervious road
-     
+
       CALL ncio_read_vector (lndname, 'T_BUILDING_MAX', landurban, t_roommax) ! maximum temperature of inner room [K]
       CALL ncio_read_vector (lndname, 'T_BUILDING_MIN', landurban, t_roommin) ! minimum temperature of inner room [K]
       CALL ncio_read_vector (lndname, 'THICK_ROOF'    , landurban, thickroof) ! thickness of roof [m]
@@ -88,7 +88,7 @@ SUBROUTINE Urban_readin (year, dir_landdata)!(dir_srfdata,dir_atmdata,nam_urbdat
       CALL ncio_read_vector (lndname, 'TK_ROOF'       , nl_roof, landurban, tk_roof) ! thermal conductivity of roof [W/m-K]
       CALL ncio_read_vector (lndname, 'TK_WALL'       , nl_wall, landurban, tk_wall) ! thermal conductivity of wall [W/m-K]
       CALL ncio_read_vector (lndname, 'TK_IMPROAD'    , nl_soil, landurban, tk_gimp) ! thermal conductivity of impervious road [W/m-K]
-#endif      
+#endif
 
 !TODO: add point case
 #ifdef SinglePoint
@@ -101,7 +101,7 @@ SUBROUTINE Urban_readin (year, dir_landdata)!(dir_srfdata,dir_atmdata,nam_urbdat
       CALL ncio_read_bcast_serial (landname, "building_mean_height"     , hroof   ) ! average building height
       CALL ncio_read_bcast_serial (landname, "tree_mean_height"         , htop_urb) ! urban tree crown top
       CALL ncio_read_bcast_serial (landname, "canyon_height_width_ratio", hwr     ) ! average building height to their distance
-      
+
       wtperroad    (1,1,:) = 1 - (prwt-rfwt)/(1-rfwt-wpct) !1. - prwt
 #endif
 
@@ -136,7 +136,7 @@ SUBROUTINE Urban_readin (year, dir_landdata)!(dir_srfdata,dir_atmdata,nam_urbdat
       print*, lndname
       CALL ncio_read_vector (lndname, 'URBAN_TREE_TOP', landurban, htop_urb)
 
-      lndname = trim("/stu01/dongwz/data/CLMrawdata/urban_5x5/LUCY_rawdata.nc")
+      lndname = trim("/stu01/dongwz/data/CLMrawdata/urban/LUCY_rawdata.nc")
       print*, lndname
       CALL ncio_read_bcast_serial (lndname,  "vehicle"    , lvehicle     )
       CALL ncio_read_bcast_serial (lndname,  "weekendday" , lweek_holiday)

--- a/mksrfdata/aggregation_urban.F90
+++ b/mksrfdata/aggregation_urban.F90
@@ -711,7 +711,7 @@ SUBROUTINE aggregation_urban (dir_rawdata, dir_srfdata, lc_year, &
       ! loop for each urban patch to aggregate NCAR urban morphological and thermal paras with area-weighted average
       DO iurban = 1, numurban
          CALL aggregation_request_data (landurban, iurban, grid_urban_500m, area = area_one, &
-                                        data_i4_2d_in2 = reg_typid, data_i4_2d_out2 = reg_typid_one)
+                                        data_i4_2d_in1 = reg_typid, data_i4_2d_out1 = reg_typid_one)
 
          ! urban region and type id for look-up-table
          urb_typidx = landurban%settyp(iurban)

--- a/mksrfdata/mksrfdata.F90
+++ b/mksrfdata/mksrfdata.F90
@@ -84,7 +84,7 @@ PROGRAM mksrfdata
    REAL(r8) :: edgew  ! western edge of grid (degrees)
 
    TYPE (grid_type) :: gridlai, gnitrif, gndep, gfire, gtopo
-   TYPE (grid_type) :: grid_urban_5km, grid_urban_100m, grid_urban_500m
+   TYPE (grid_type) :: grid_urban_5km, grid_urban_500m
 
    INTEGER   :: lc_year
    INTEGER*8 :: start_time, end_time, c_per_sec, time_used
@@ -213,17 +213,6 @@ PROGRAM mksrfdata
    CALL gurban%define_by_name          ('colm_500m')
    CALL grid_urban_500m%define_by_name ('colm_500m')
    CALL grid_urban_5km%define_by_name  ('colm_5km' )
-   CALL grid_urban_100m%define_by_name ('colm_100m')
-
-   CALL pixel%assimilate_grid (gurban         )
-   CALL pixel%assimilate_grid (grid_urban_500m)
-   CALL pixel%assimilate_grid (grid_urban_5km )
-   CALL pixel%assimilate_grid (grid_urban_100m)
-
-   CALL pixel%map_to_grid (gurban         )
-   CALL pixel%map_to_grid (grid_urban_500m)
-   CALL pixel%map_to_grid (grid_urban_5km )
-   CALL pixel%map_to_grid (grid_urban_100m)
 #endif
 
    ! assimilate grids to build pixels
@@ -238,6 +227,13 @@ PROGRAM mksrfdata
 #endif
    CALL pixel%assimilate_grid (gpatch)
    CALL pixel%assimilate_grid (gridlai)
+
+#ifdef URBAN_MODEL
+   CALL pixel%assimilate_grid (gurban         )
+   CALL pixel%assimilate_grid (grid_urban_500m)
+   CALL pixel%assimilate_grid (grid_urban_5km )
+#endif
+
 #ifdef BGC
 #if (defined CROP)
    CALL pixel%assimilate_grid (gcrop )
@@ -264,6 +260,13 @@ PROGRAM mksrfdata
    CALL pixel%map_to_grid (ghru)
 #endif
    CALL pixel%map_to_grid (gpatch)
+
+#ifdef URBAN_MODEL
+   CALL pixel%map_to_grid (gurban         )
+   CALL pixel%map_to_grid (grid_urban_500m)
+   CALL pixel%map_to_grid (grid_urban_5km )
+#ENDIF
+
 #if (defined CROP)
    CALL pixel%map_to_grid (gcrop )
 #endif
@@ -296,16 +299,16 @@ PROGRAM mksrfdata
    ! build land patches
    CALL landpatch_build(lc_year)
 
+#ifdef URBAN_MODEL
+   CALL landurban_build(lc_year)
+#endif
+
 #ifdef PFT_CLASSIFICATION
    CALL landpft_build(lc_year)
 #endif
 
 #ifdef PC_CLASSIFICATION
    CALL landpc_build(lc_year)
-#endif
-
-#ifdef URBAN_MODEL
-   CALL landurban_build(lc_year)
 #endif
 
    ! ................................................................
@@ -324,7 +327,6 @@ PROGRAM mksrfdata
    CALL pixelset_save_to_file  (lc_year, dir_landdata, 'landhru', landhru)
 #endif
 
-   print*, count(landpatch%settyp==13)
    CALL pixelset_save_to_file  (lc_year, dir_landdata, 'landpatch', landpatch)
 
 #ifdef PFT_CLASSIFICATION
@@ -385,7 +387,7 @@ PROGRAM mksrfdata
 
 #ifdef URBAN_MODEL
    CALL aggregation_urban (dir_rawdata, dir_landdata, lc_year, &
-                           grid_urban_5km, grid_urban_100m, grid_urban_500m)
+                           grid_urban_5km, grid_urban_500m)
 #endif
 
 

--- a/mksrfdata/mod_landelm.F90
+++ b/mksrfdata/mod_landelm.F90
@@ -13,7 +13,7 @@ MODULE mod_landelm
 CONTAINS
 
    ! -------------------------------
-   SUBROUTINE landelm_build 
+   SUBROUTINE landelm_build
 
       USE precision
       USE spmd_task
@@ -37,8 +37,8 @@ CONTAINS
 
          DO ielm = 1, numelm
             landelm%eindex(ielm) = mesh(ielm)%indx
-            landelm%ipxstt(ielm) = 1 
-            landelm%ipxend(ielm) = mesh(ielm)%npxl 
+            landelm%ipxstt(ielm) = 1
+            landelm%ipxend(ielm) = mesh(ielm)%npxl
             landelm%settyp(ielm) = 0
             landelm%ielm  (ielm) = ielm
          ENDDO
@@ -46,7 +46,7 @@ CONTAINS
       ENDIF
 
       landelm%nset = numelm
-      CALL landelm%set_vecgs 
+      CALL landelm%set_vecgs
 
 #ifdef USEMPI
       CALL mpi_barrier (p_comm_glb, p_err)
@@ -54,7 +54,7 @@ CONTAINS
       IF (p_is_worker) THEN
          CALL mpi_reduce (numelm, nelm_glb, 1, MPI_INTEGER, MPI_SUM, p_root, p_comm_worker, p_err)
          IF (p_iam_worker == 0) THEN
-            write(*,'(A,I12,A)') 'Total: ', nelm_glb, ' elements.' 
+            write(*,'(A,I12,A)') 'Total: ', nelm_glb, ' elements.'
          ENDIF
       ENDIF
 

--- a/mksrfdata/mod_landpatch.F90
+++ b/mksrfdata/mod_landpatch.F90
@@ -118,12 +118,12 @@ CONTAINS
       IF (p_is_io) THEN
          CALL allocate_block_data (gpatch, patchdata)
 
-         !TODO: add parameter input for time year
-!#ifdef IGBP_CLASSIFICATION
+         !TODO-done: add parameter input for time year
+#ifndef USGS_CLASSIFICATION
          file_patch = trim(DEF_dir_rawdata)//'landtypes-modis-igbp-'//trim(cyear)//'.nc'
-!#endif
-#ifdef USGS_CLASSIFICATION
-         file_patch = trim(DEF_dir_rawdata) // '/landtype_update.nc'
+#else
+         !TODO: need usgs land cover TYPE data
+         !file_patch = trim(DEF_dir_rawdata) // '/landtype_update.nc'
 #endif
          CALL ncio_read_block (file_patch, 'landtype', gpatch, patchdata)
 
@@ -297,6 +297,9 @@ CONTAINS
          IF (allocated(msk)) deallocate(msk)
       ENDIF
 
+#ifdef URBAN_MODEL
+      continue
+#else
 #if (defined CROP)
       IF (p_is_io) THEN
 !         file_patch = trim(DEF_dir_rawdata) // '/global_0.5x0.5.MOD2005_V4.5_CFT_mergetoclmpft.nc'
@@ -341,7 +344,7 @@ CONTAINS
 #endif
 
       CALL write_patchfrac (DEF_dir_landdata, lc_year)
-
+#endif
    END SUBROUTINE landpatch_build
 
    ! -----


### PR DESCRIPTION
1. move DEF_LC_YEAR to mksrf.F90, lc_year is an input parameters now.
-mod(mksrf/mod_land*.F90&mod_srfdata_restart.F90): add lc_year parameter
-mod(mkini/MOD_Urban_Readin.F90): add lc_year parameter to read urban data
-mod(main/mod_TimeInvariants.F90): add lc_year to distinguish constant variable of different year
-mod(main/CoLM.F90): add lc_year to read land data
-mod(mkinidata/CoLMINI.F90): add lc_year to read land data

2. fix bugs of srf_diag when using urban model and aggregation_urban
-mod(mksrf/mod_landurban.F90): add write_patchfrac code
-mod(mksrf/mod_landpatch.F90): if define urban model, write_patchfrac will be executed in mod_landurban.F90
-mod(mksrf/mksrf.F90): change order, landurban_build is now after landpatch_build, remove grid_urban_100m, LCZ will use grid_urban_500m with PCT_LCZ of 500m resolution
-mod(mksrf/aggregation_urban.F90): assign region id for a specific area, due to this area having no data of ncar urban

